### PR TITLE
Automate PHP Install & Start Server in CMD

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,30 @@
+@echo off
+
+openfiles >nul 2>nul
+if %errorlevel% neq 0 (
+    echo This script needs to be run with administrative privileges.
+    echo Please run this script as an administrator.
+    pause
+    exit
+)
+
+php -v >nul 2>nul
+if %errorlevel% equ 0 (
+    echo PHP is already installed.
+) else (
+    echo PHP is not installed. Proceeding with PHP installation...
+    echo Downloading PHP...
+    powershell -Command "Invoke-WebRequest -Uri https://windows.php.net/downloads/releases/php-8.3.13-Win32-vs16-x64.zip -OutFile php.zip"
+    echo Extracting PHP...
+    powershell -Command "Expand-Archive -Path php.zip -DestinationPath C:\php -Force"
+    echo Adding PHP to the PATH...
+    setx PATH "%PATH%;C:\php"
+    del php.zip
+    echo PHP installation complete.
+)
+
+echo Starting PHP server and Job Search app...
+start cmd /K "cd /d %~dp0 && php -S localhost:8080"
+start http://localhost:8080
+
+pause


### PR DESCRIPTION
-Checks if PHP is installed. If not, downloads and extracts the latest PHP version. 
-Adds PHP to the system's PATH environment variable. 
-Starts a new command prompt window in the script's directory to run the PHP built-in server on localhost:8080. 
-Opens the default web browser to access the PHP app at http://localhost:8080. 
-Adds a pause at the end of the script to keep the command prompt open for user interaction.